### PR TITLE
Add tool GrokMarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,7 @@ No official Linux desktop app. The Bot computer in the cloud is already Linux. T
 
 - [botdirectory.ai](https://github.com/elie222/botdirectory.ai) - Community prompt directory. Paste a listing into Grok Bot and it sets itself up.
 - [GrokBotDev](https://github.com/ZeroPointRepo/GrokBotDev) - Agent-run directory of prompts, plugins, and use cases. PRs are the write API.
+- [GrokMarket](https://grokmarket.io) - Independent directory of public Grok Bot templates with prompts, usage notes, creator attribution, and live x.ai previews.
 - [ZeroPointRepo/awesome-grok-bot](https://github.com/ZeroPointRepo/awesome-grok-bot) - Day-one directory, strong on marketplace format and self-hosted runtimes.
 - [awesome-grok-bot-plugins](https://github.com/rdmgator12/awesome-grok-bot-plugins) - 219 in-app marketplace listings captured 2026-08-12, grouped by category.
 - [Anil-matcha/awesome-grok-bot](https://github.com/Anil-matcha/awesome-grok-bot) - Ready-to-paste prompt library across productivity, sales, marketing, and ops.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -698,6 +698,7 @@ Zoom 桌面授权目前会报 4700。已经有 Ultra 再绑 SuperGrok Plus 不�
 
 - [botdirectory.ai](https://github.com/elie222/botdirectory.ai) - 社区提示词目录。把一条贴进 Grok Bot，它会自己搭起来。
 - [GrokBotDev](https://github.com/ZeroPointRepo/GrokBotDev) - 代理在跑的提示词、插件和用法目录。PR 就是写入接口。
+- [GrokMarket](https://grokmarket.io) - 公开 Grok Bot 模板的独立目录，提供提示词、使用说明、作者来源和 x.ai 在线预览。
 - [ZeroPointRepo/awesome-grok-bot](https://github.com/ZeroPointRepo/awesome-grok-bot) - 第一天就立的目录，市场格式和自托管运行时写得细。
 - [awesome-grok-bot-plugins](https://github.com/rdmgator12/awesome-grok-bot-plugins) - 2026 年 8 月 12 日抓到的 219 条应用内市场上架，按类排。
 - [Anil-matcha/awesome-grok-bot](https://github.com/Anil-matcha/awesome-grok-bot) - 可粘贴的提示词库，覆盖效率、销售、营销和运营。


### PR DESCRIPTION
Adds GrokMarket to the Indexes section in both English and Chinese.

GrokMarket is an independent directory of public Grok Bot templates with prompts, usage notes, creator attribution, and live x.ai previews.

Validation: `node scripts/lint.mjs` → `OK 377 entries`.